### PR TITLE
Enable inheritance

### DIFF
--- a/src/LSM6DS3.cpp
+++ b/src/LSM6DS3.cpp
@@ -19,33 +19,6 @@
 
 #include "LSM6DS3.h"
 
-#define LSM6DS3_ADDRESS            0x6A
-
-#define LSM6DS3_WHO_AM_I_REG       0X0F
-#define LSM6DS3_CTRL1_XL           0X10
-#define LSM6DS3_CTRL2_G            0X11
-
-#define LSM6DS3_STATUS_REG         0X1E
-
-#define LSM6DS3_CTRL6_C            0X15
-#define LSM6DS3_CTRL7_G            0X16
-#define LSM6DS3_CTRL8_XL           0X17
-
-#define LSM6DS3_OUTX_L_G           0X22
-#define LSM6DS3_OUTX_H_G           0X23
-#define LSM6DS3_OUTY_L_G           0X24
-#define LSM6DS3_OUTY_H_G           0X25
-#define LSM6DS3_OUTZ_L_G           0X26
-#define LSM6DS3_OUTZ_H_G           0X27
-
-#define LSM6DS3_OUTX_L_XL          0X28
-#define LSM6DS3_OUTX_H_XL          0X29
-#define LSM6DS3_OUTY_L_XL          0X2A
-#define LSM6DS3_OUTY_H_XL          0X2B
-#define LSM6DS3_OUTZ_L_XL          0X2C
-#define LSM6DS3_OUTZ_H_XL          0X2D
-
-
 LSM6DS3Class::LSM6DS3Class(TwoWire& wire, uint8_t slaveAddress) :
   _wire(&wire),
   _spi(NULL),

--- a/src/LSM6DS3.h
+++ b/src/LSM6DS3.h
@@ -69,7 +69,7 @@ class LSM6DS3Class {
     virtual int gyroscopeAvailable(); // Check for available data from gyroscope
 
 
-  private:
+  protected:
     int readRegister(uint8_t address);
     int readRegisters(uint8_t address, uint8_t* data, size_t length);
     int writeRegister(uint8_t address, uint8_t value);

--- a/src/LSM6DS3.h
+++ b/src/LSM6DS3.h
@@ -21,6 +21,33 @@
 #include <Wire.h>
 #include <SPI.h>
 
+#define LSM6DS3_ADDRESS            0x6A
+
+#define LSM6DS3_WHO_AM_I_REG       0X0F
+#define LSM6DS3_CTRL1_XL           0X10
+#define LSM6DS3_CTRL2_G            0X11
+
+#define LSM6DS3_STATUS_REG         0X1E
+
+#define LSM6DS3_CTRL6_C            0X15
+#define LSM6DS3_CTRL7_G            0X16
+#define LSM6DS3_CTRL8_XL           0X17
+
+#define LSM6DS3_OUTX_L_G           0X22
+#define LSM6DS3_OUTX_H_G           0X23
+#define LSM6DS3_OUTY_L_G           0X24
+#define LSM6DS3_OUTY_H_G           0X25
+#define LSM6DS3_OUTZ_L_G           0X26
+#define LSM6DS3_OUTZ_H_G           0X27
+
+#define LSM6DS3_OUTX_L_XL          0X28
+#define LSM6DS3_OUTX_H_XL          0X29
+#define LSM6DS3_OUTY_L_XL          0X2A
+#define LSM6DS3_OUTY_H_XL          0X2B
+#define LSM6DS3_OUTZ_L_XL          0X2C
+#define LSM6DS3_OUTZ_H_XL          0X2D
+
+
 
 class LSM6DS3Class {
   public:


### PR DESCRIPTION
Recently I attempted to subclass `LSM6DS3Class` in order to add additional functionality in my sketch,  I discovered that many of the `define`s I expected to work such as register addresses and LSM6DS3_ADDRESS are defined in the LSM6DS3.cpp file and including Arduino_LSM6DS3.h will not be enough.  A simple fix and also a good practice would be to move these defines in the to the LSM6DS3.h.

In addition in order to enable inheritance private methods are now declared as protected