### PR TITLE
Update LSM6DS3.cpp

### DIFF
--- a/src/LSM6DS3.cpp
+++ b/src/LSM6DS3.cpp
@@ -79,7 +79,7 @@ void LSM6DS3Class::end()
   } else {
     writeRegister(LSM6DS3_CTRL2_G, 0x00);
     writeRegister(LSM6DS3_CTRL1_XL, 0x00);
-    _wire->end();
+    _wire->endTransmission();
   }
 }
 


### PR DESCRIPTION
I noticed that on modern Arduino Uno Wifi R2 the end() is not defined, and it does not compile.

However, with endTransmission() it does.